### PR TITLE
Enhance project structure and add tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,4 +2,4 @@ from flask import Flask
 
 app = Flask(__name__)
 
-from . import cut_optimizer_app
+from . import cut_optimizer_app  # noqa: F401,E402

--- a/forgecore/backend/agent_api/main.py
+++ b/forgecore/backend/agent_api/main.py
@@ -6,8 +6,6 @@ import argparse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 
-from ...config.config import POOL
-
 
 class SimpleHandler(BaseHTTPRequestHandler):
     def do_GET(self):

--- a/forgecore/backend/cutlist_optimizer/main.py
+++ b/forgecore/backend/cutlist_optimizer/main.py
@@ -5,7 +5,6 @@ and matches best cuts from available stock.
 
 import argparse
 from typing import List, Tuple
-import mysql.connector
 
 from ...config.config import POOL
 

--- a/forgecore/config/config.py
+++ b/forgecore/config/config.py
@@ -1,7 +1,6 @@
 """Configuration and database connector for ForgeCore."""
 
 import os
-import mysql.connector
 from mysql.connector import pooling
 
 

--- a/tests/test_cut_optimizer_app.py
+++ b/tests/test_cut_optimizer_app.py
@@ -1,0 +1,38 @@
+import unittest
+from app.cut_optimizer_app import (
+    parse_length,
+    parse_parts,
+    parse_stock,
+    optimize_cuts,
+)
+
+
+class TestCutOptimizer(unittest.TestCase):
+    def test_parse_length(self):
+        self.assertAlmostEqual(parse_length("7' 6"), 90.0)
+        self.assertAlmostEqual(parse_length("10'"), 120.0)
+        self.assertAlmostEqual(parse_length("18 3/8"), 18.375)
+
+    def test_parse_parts_and_stock(self):
+        parts_text = """1 CA195 7'
+2 CA100 3' 6"""
+        stock_text = "1 10'\n1 8'"
+        parts = parse_parts(parts_text)
+        self.assertEqual(len(parts), 3)
+        stock = parse_stock(stock_text)
+        self.assertEqual(len(stock), 2)
+
+    def test_optimize_cuts(self):
+        parts = [
+            {'mark': 'A', 'length': 60, 'length_str': "5'"},
+            {'mark': 'B', 'length': 48, 'length_str': "4'"},
+        ]
+        stock = [{'length': 120, 'length_str': "10'"}]
+        bins, uncut = optimize_cuts(parts, stock)
+        self.assertEqual(len(uncut), 0)
+        self.assertEqual(len(bins[0]['parts']), 2)
+        self.assertAlmostEqual(bins[0]['remaining'], 12)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for cut optimizer helpers
- clean up flake8 issues in backend modules
- note module import in `app/__init__.py`

## Testing
- `flake8 --ignore=E501`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a50abb6d0832483ded64dfb8261cc