### PR TITLE
Add stick layout visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Enter your parts list and stock inventory using real-world formats like `14' 3 1
 🧠 **Smart Cut Optimization**  
 Uses a First-Fit Decreasing (FFD) nesting algorithm to assign parts to stock lengths while minimizing waste. Simple, fast, and effective.
 
-📊 **Clear, Interactive Output**  
+📊 **Clear, Interactive Output**
 Get a complete breakdown of which parts are cut from which sticks, how much material is used, and how much is left.
+
+📐 **Stick Layout Diagram**
+Visual diagram showing where each part fits on a stock stick right in the results page.
 
 📝 **Web Interface**  
 Lightweight Flask-based interface. No installation mess. Enter your data, hit optimize, and go.
@@ -94,8 +97,8 @@ Then open [http://127.0.0.1:5000](http://127.0.0.1:5000) in your browser 🧠�
 
 ## 🧭 Roadmap
 - [x] Kerf width input
-- [ ] Visual stick layout diagram
- - [x] CSV import/export
+- [x] Visual stick layout diagram
+- [x] CSV import/export
 - [ ] PDF cut sheet generator
 - [ ] Mobile-friendly layout
 - [ ] Auto-saving job history

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -47,3 +47,23 @@ td, th {
     border: 1px solid #ccc;
     padding: 8px;
 }
+
+.stick {
+    display: flex;
+    height: 20px;
+    margin-top: 10px;
+    background: #e0e0e0;
+}
+.stick span {
+    display: block;
+    height: 100%;
+}
+.stick .kerf {
+    background: #fff;
+}
+.stick .scrap {
+    background: #f44336;
+}
+.stick .part {
+    background: #4caf50;
+}

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -32,6 +32,15 @@
     </tr>
     {% endfor %}
 </table>
+
+<h2>Layout</h2>
+{% for b, segments in zip(bins, layout) %}
+<div class="stick">
+    {% for seg in segments %}
+    <span class="{{ seg.label|lower }}" style="width: {{ (seg.length / b.stock_length) * 100 }}%" title="{{ seg.label }} - {{ format_length(seg.length) }}"></span>
+    {% endfor %}
+</div>
+{% endfor %}
 {% if uncut %}
 <h2>Uncut Parts</h2>
 <ul>

--- a/tests/test_cut_optimizer_app.py
+++ b/tests/test_cut_optimizer_app.py
@@ -10,6 +10,7 @@ from app.cut_optimizer_app import (
     parse_stock_csv,
     optimize_cuts,
     export_cutting_plan_pdf,
+    generate_layout_data,
 )
 
 
@@ -71,6 +72,23 @@ class TestCutOptimizer(unittest.TestCase):
             export_cutting_plan_pdf(bins, uncut, 0.0, str(path))
             self.assertTrue(path.exists())
             self.assertGreater(path.stat().st_size, 0)
+
+    def test_generate_layout_data(self):
+        bins = [
+            {
+                'stock_length': 100,
+                'remaining': 20,
+                'parts': [
+                    {'mark': 'A', 'length': 40},
+                    {'mark': 'B', 'length': 40},
+                ],
+            }
+        ]
+        layout = generate_layout_data(bins, 0.0)
+        self.assertEqual(len(layout), 1)
+        segments = layout[0]
+        total = sum(s['length'] for s in segments)
+        self.assertAlmostEqual(total, 100)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- visualize part layout on each stock stick
- show layout section on results page with simple styling
- compute layout data in backend
- test layout data generation
- mention layout diagram in docs and roadmap

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503098b64c83249869575fb90b0020