### PR TITLE
Add PDF export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Then open [http://127.0.0.1:5000](http://127.0.0.1:5000) in your browser ðŸ§ ðŸ’
 - [x] Kerf width input
 - [x] Visual stick layout diagram
 - [x] CSV import/export
-- [ ] PDF cut sheet generator
+- [x] PDF cut sheet generator
 - [ ] Mobile-friendly layout
 - [ ] Auto-saving job history
 

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -49,6 +49,9 @@
 {% endfor %}
 </ul>
 {% endif %}
+<p>
+    <a href="{{ url_for('download_pdf', filename=pdf_filename) }}">Download PDF</a>
+</p>
 <a href="/">Back</a>
 </body>
 </html>

--- a/tests/test_cut_optimizer_app.py
+++ b/tests/test_cut_optimizer_app.py
@@ -1,5 +1,6 @@
 import unittest
 import io
+import os
 import pathlib
 import tempfile
 from app.cut_optimizer_app import (
@@ -11,6 +12,7 @@ from app.cut_optimizer_app import (
     optimize_cuts,
     export_cutting_plan_pdf,
     generate_layout_data,
+    app,
 )
 
 
@@ -89,6 +91,24 @@ class TestCutOptimizer(unittest.TestCase):
         segments = layout[0]
         total = sum(s['length'] for s in segments)
         self.assertAlmostEqual(total, 100)
+
+    def test_download_pdf_route(self):
+        client = app.test_client()
+        bins = [
+            {
+                'stock_length': 120,
+                'used': 120,
+                'remaining': 0,
+                'parts': [{'mark': 'A', 'length': 120, 'length_str': "10'"}],
+            }
+        ]
+        uncut = []
+        path = os.path.join(tempfile.gettempdir(), 'route_test.pdf')
+        export_cutting_plan_pdf(bins, uncut, 0.0, path)
+        resp = client.get(f'/download_pdf/{os.path.basename(path)}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.mimetype, 'application/pdf')
+        os.remove(path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- integrate PDF cut sheet generation with Flask app
- serve the generated PDF through `/download_pdf/<filename>` route
- link to the PDF on results page
- mark feature complete in README
- test the download route

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68508031379083248cbde4a021572750