### PR TITLE
Add CSV export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Uses a First-Fit Decreasing (FFD) nesting algorithm to assign parts to stock len
 📊 **Clear, Interactive Output**
 Get a complete breakdown of which parts are cut from which sticks, how much material is used, and how much is left.
 
+📄 **CSV Cut Plan Export**
+Download the optimized plan as a CSV file for use in spreadsheets or other tools.
+
 📐 **Stick Layout Diagram**
 Visual diagram showing where each part fits on a stock stick right in the results page.
 

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -52,6 +52,8 @@
 {% endif %}
 <p>
     <a href="{{ url_for('download_pdf', filename=pdf_filename) }}">Download PDF</a>
+    |
+    <a href="{{ url_for('download_csv', filename=csv_filename) }}">Download CSV</a>
 </p>
 <a href="/">Back</a>
 </body>


### PR DESCRIPTION
## Summary
- export optimized cut plan to CSV
- add link to download CSV in results page
- update documentation for new CSV export
- test CSV export and download route

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540e7b0d1883248d061a835cae10ad