### PR TITLE
Add deployment modes and env validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,16 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 
 ### 3. Install Flask
 ```bash
-pip install -r requirements.txt
+pip install --upgrade -r requirements.txt
 ```
 
 ### 4. Run the App
 ```bash
-python app/cut_optimizer_app.py
+python app/cut_optimizer_app.py [--dev|--prod]
 ```
+
+Ensure the following environment variables are set before running:
+`FORGECORE_DB_HOST`, `FORGECORE_DB_USER`, `FORGECORE_DB_PASSWORD`, and `FORGECORE_DB_NAME`.
 
 Then open [http://127.0.0.1:5000](http://127.0.0.1:5000) in your browser 🧠💥
 

--- a/app/cut_optimizer_app.py
+++ b/app/cut_optimizer_app.py
@@ -371,4 +371,34 @@ def optimize():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import argparse
+
+    def check_env_vars():
+        required = [
+            'FORGECORE_DB_HOST',
+            'FORGECORE_DB_USER',
+            'FORGECORE_DB_PASSWORD',
+            'FORGECORE_DB_NAME',
+        ]
+        missing = [v for v in required if not os.getenv(v)]
+        if missing:
+            raise RuntimeError(
+                f"Missing required environment variables: {', '.join(missing)}"
+            )
+
+    parser = argparse.ArgumentParser(description='Run the BladePlan Flask app')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--dev', action='store_true', help='Run in development mode')
+    group.add_argument('--prod', action='store_true', help='Run in production mode')
+    args = parser.parse_args()
+
+    check_env_vars()
+
+    if args.dev:
+        os.environ['FLASK_ENV'] = 'development'
+        debug = True
+    else:
+        os.environ['FLASK_ENV'] = 'production'
+        debug = False
+
+    app.run(debug=debug)

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,38 @@ fi
 source venv/bin/activate
 
 # Install required Python packages
-pip install -r requirements.txt
+pip install --upgrade -r requirements.txt
+
+# Parse command line arguments for mode
+MODE="production"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dev)
+            MODE="development"
+            shift
+            ;;
+        --prod)
+            MODE="production"
+            shift
+            ;;
+        *)
+            echo "Usage: $0 [--dev|--prod]"
+            exit 1
+            ;;
+    esac
+done
+
+# Ensure required ForgeCore environment variables are set
+REQUIRED_VARS=(FORGECORE_DB_HOST FORGECORE_DB_USER FORGECORE_DB_PASSWORD FORGECORE_DB_NAME)
+for var in "${REQUIRED_VARS[@]}"; do
+    if [ -z "${!var}" ]; then
+        echo "Error: $var is not set" >&2
+        exit 1
+    fi
+done
+
+# Set Flask environment
+export FLASK_ENV="$MODE"
 
 # Start the Flask application
 python app/cut_optimizer_app.py


### PR DESCRIPTION
## Summary
- upgrade dependencies in deploy script
- support `--dev` and `--prod` options
- verify required DB env vars before launching
- expose the new CLI options in the Flask app
- document updated install and run steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c613fcf248324b0ed06b4ee6f0029