### PR TITLE
Add segment tooltips and styling

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -65,14 +65,29 @@ td, th {
     white-space: nowrap;
     overflow: hidden;
 }
-.stick .kerf {
-    background: #fff;
+
+.segment.part {
+    background: #4caf50;
 }
-.stick .scrap {
+
+.segment.kerf {
+    background: #ffffff;
+}
+
+.segment.scrap {
     background: #f44336;
 }
-.stick .part {
-    background: #4caf50;
+
+#tooltip {
+    position: absolute;
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    pointer-events: none;
+    display: none;
+    z-index: 10;
 }
 
 @media (max-width: 600px) {

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -41,10 +41,27 @@
 {% for b, segments in zip(bins, layout) %}
 <div class="stick">
     {% for seg in segments %}
-    <span class="{{ seg.label|lower }}" style="width: {{ (seg.length / b.stock_length) * 100 }}%" title="{{ seg.label }} - {{ format_length(seg.length) }}">{{ seg.label }}</span>
+    <span class="segment {{ seg.type }}" data-mark="{{ seg.label }}" data-length="{{ format_length(seg.length) }}" style="width: {{ (seg.length / b.stock_length) * 100 }}%">{{ seg.label }}</span>
     {% endfor %}
 </div>
 {% endfor %}
+<div id="tooltip"></div>
+<script>
+    const tooltip = document.getElementById('tooltip');
+    document.querySelectorAll('.segment').forEach(el => {
+        el.addEventListener('mouseenter', () => {
+            tooltip.textContent = `${el.dataset.mark} - ${el.dataset.length}`;
+            tooltip.style.display = 'block';
+        });
+        el.addEventListener('mousemove', e => {
+            tooltip.style.left = `${e.pageX + 10}px`;
+            tooltip.style.top = `${e.pageY + 10}px`;
+        });
+        el.addEventListener('mouseleave', () => {
+            tooltip.style.display = 'none';
+        });
+    });
+</script>
 {% if uncut %}
 <h2>Uncut Parts</h2>
 <ul>


### PR DESCRIPTION
## Summary
- add type information to generated layout segments
- style segment types and tooltip in CSS
- show length + mark tooltips on layout hover

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c614c2dec8324861ae041995f4f7d