### PR TITLE
Enhance validation for lengths and quantities

### DIFF
--- a/app/cut_optimizer_app.py
+++ b/app/cut_optimizer_app.py
@@ -63,7 +63,7 @@ def parse_parts(text: str):
             raise ValueError(f"Invalid part line: '{line}'")
 
         qty_str = tokens[0]
-        if not qty_str.isdigit():
+        if not qty_str.isdigit() or int(qty_str) <= 0:
             raise ValueError(f"Invalid quantity '{qty_str}' in line: '{line}'")
         qty = int(qty_str)
 
@@ -71,6 +71,8 @@ def parse_parts(text: str):
         length_str = ' '.join(tokens[2:])
         try:
             length = parse_length(length_str)
+            if length <= 0:
+                raise ValueError("length must be positive")
         except ValueError as exc:
             raise ValueError(f"Invalid length in line '{line}': {exc}") from exc
 
@@ -90,13 +92,15 @@ def parse_stock(text: str):
             raise ValueError(f"Invalid stock line: '{line}'")
 
         qty_str = tokens[0]
-        if not qty_str.isdigit():
+        if not qty_str.isdigit() or int(qty_str) <= 0:
             raise ValueError(f"Invalid quantity '{qty_str}' in line: '{line}'")
         qty = int(qty_str)
 
         length_str = ' '.join(tokens[1:])
         try:
             length = parse_length(length_str)
+            if length <= 0:
+                raise ValueError("length must be positive")
         except ValueError as exc:
             raise ValueError(f"Invalid length in line '{line}': {exc}") from exc
 
@@ -117,7 +121,7 @@ def parse_parts_csv(file) -> list:
     reader = csv.DictReader(io.StringIO(text))
     for row in reader:
         qty_str = row.get('qty', '').strip()
-        if not qty_str.isdigit():
+        if not qty_str.isdigit() or int(qty_str) <= 0:
             raise ValueError(f"Invalid quantity '{qty_str}' in parts CSV")
         qty = int(qty_str)
 
@@ -127,6 +131,8 @@ def parse_parts_csv(file) -> list:
             raise ValueError("Missing length in parts CSV")
         try:
             length = parse_length(length_str)
+            if length <= 0:
+                raise ValueError("length must be positive")
         except ValueError as exc:
             raise ValueError(f"Invalid length '{length_str}' in parts CSV: {exc}") from exc
 
@@ -145,7 +151,7 @@ def parse_stock_csv(file) -> list:
     reader = csv.DictReader(io.StringIO(text))
     for row in reader:
         qty_str = row.get('qty', '').strip()
-        if not qty_str.isdigit():
+        if not qty_str.isdigit() or int(qty_str) <= 0:
             raise ValueError(f"Invalid quantity '{qty_str}' in stock CSV")
         qty = int(qty_str)
 
@@ -154,6 +160,8 @@ def parse_stock_csv(file) -> list:
             raise ValueError("Missing length in stock CSV")
         try:
             length = parse_length(length_str)
+            if length <= 0:
+                raise ValueError("length must be positive")
         except ValueError as exc:
             raise ValueError(f"Invalid length '{length_str}' in stock CSV: {exc}") from exc
 

--- a/tests/test_cut_optimizer_app.py
+++ b/tests/test_cut_optimizer_app.py
@@ -43,6 +43,20 @@ class TestCutOptimizer(unittest.TestCase):
         self.assertEqual(len(parts), 1)
         self.assertEqual(len(stock), 1)
 
+    def test_parse_csv_negative_values(self):
+        bad_parts = io.StringIO('qty,mark,length\n0,A,5\'\n')
+        with self.assertRaises(ValueError):
+            parse_parts_csv(bad_parts)
+        bad_parts_len = io.StringIO('qty,mark,length\n1,A,-5\n')
+        with self.assertRaises(ValueError):
+            parse_parts_csv(bad_parts_len)
+        bad_stock = io.StringIO('qty,length\n0,10\'\n')
+        with self.assertRaises(ValueError):
+            parse_stock_csv(bad_stock)
+        bad_stock_len = io.StringIO('qty,length\n1,-10\n')
+        with self.assertRaises(ValueError):
+            parse_stock_csv(bad_stock_len)
+
     def test_optimize_cuts(self):
         parts = [
             {'mark': 'A', 'length': 60, 'length_str': "5'"},
@@ -155,6 +169,16 @@ class TestCutOptimizer(unittest.TestCase):
     def test_invalid_stock_input(self):
         with self.assertRaises(ValueError):
             parse_stock("x y")
+
+    def test_negative_values(self):
+        with self.assertRaises(ValueError):
+            parse_parts("0 A 5'")
+        with self.assertRaises(ValueError):
+            parse_parts("1 A -5")
+        with self.assertRaises(ValueError):
+            parse_stock("0 10'")
+        with self.assertRaises(ValueError):
+            parse_stock("1 -10")
 
     def test_optimize_route_invalid_input(self):
         client = app.test_client()


### PR DESCRIPTION
## Summary
- ensure quantity and lengths are positive in parsers
- expand unit tests for negative quantities and lengths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c631e94608324a9f7f3f4214d122d