### PR TITLE
Add JSON export and totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Get a complete breakdown of which parts are cut from which sticks, how much mate
 📄 **CSV Cut Plan Export**
 Download the optimized plan as a CSV file for use in spreadsheets or other tools.
 
+📑 **JSON Cut Plan Export**
+Grab the results in JSON format for programmatic use.
+
+📊 **Material Totals**
+See total stock length, used material, and scrap summarized in the results page.
+
 📐 **Stick Layout Diagram**
 Visual diagram showing where each part fits on a stock stick right in the results page.
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,6 +33,7 @@
     <input type="text" id="kerf_width" name="kerf_width" placeholder="1/8&quot;" value="{{ kerf_width|default('') }}">
 
     <button type="submit">Optimize</button>
+    <button type="reset">Clear</button>
 </form>
 </body>
 </html>

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -37,6 +37,13 @@
     {% endfor %}
 </table>
 
+<h2>Totals</h2>
+<ul>
+    <li>Total Stock: {{ format_length(total_stock) }}</li>
+    <li>Total Used: {{ format_length(total_used) }}</li>
+    <li>Total Scrap: {{ format_length(total_scrap) }}</li>
+</ul>
+
 <h2>Layout</h2>
 {% for b, segments in zip(bins, layout) %}
 <div class="stick">
@@ -57,6 +64,8 @@
     <a href="{{ url_for('download_pdf', filename=pdf_filename) }}">Download PDF</a>
     |
     <a href="{{ url_for('download_csv', filename=csv_filename) }}">Download CSV</a>
+    |
+    <a href="{{ url_for('download_json', filename=json_filename) }}">Download JSON</a>
 </p>
 <a href="/">Back</a>
 </body>

--- a/tests/test_cut_optimizer_app.py
+++ b/tests/test_cut_optimizer_app.py
@@ -15,6 +15,7 @@ from app.cut_optimizer_app import (
     optimize_cuts,
     export_cutting_plan_pdf,
     export_cutting_plan_csv,
+    export_cutting_plan_json,
     generate_layout_data,
     app,
 )
@@ -160,6 +161,24 @@ class TestCutOptimizer(unittest.TestCase):
         resp = client.get(f'/download_csv/{os.path.basename(path)}')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.mimetype, 'text/csv')
+        os.remove(path)
+
+    def test_download_json_route(self):
+        client = app.test_client()
+        bins = [
+            {
+                'stock_length': 120,
+                'used': 120,
+                'remaining': 0,
+                'parts': [{'mark': 'A', 'length': 120, 'length_str': "10'"}],
+            }
+        ]
+        uncut = []
+        path = os.path.join(tempfile.gettempdir(), 'route_test.json')
+        export_cutting_plan_json(bins, uncut, 0.0, path)
+        resp = client.get(f'/download_json/{os.path.basename(path)}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.mimetype, 'application/json')
         os.remove(path)
 
     def test_invalid_parts_input(self):


### PR DESCRIPTION
## Summary
- add JSON export and totals summary page
- show overall stock used and scrap
- support JSON download route
- add Clear button on form
- update README features and tests

## Testing
- `python -m pip install -r requirements.txt`
- `python tests/test_cut_optimizer_app.py -v`

------
https://chatgpt.com/codex/tasks/task_e_686c1206208483248da07f5ea871f0d7